### PR TITLE
✨ Feature - EC2 배포에서 S3 + CloudFront 배포로 변경

### DIFF
--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -3,7 +3,7 @@ name: Deploy Vite to S3 (Dev)
 on:
   push:
     branches:
-      - dev
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -1,0 +1,36 @@
+name: Deploy Vite to S3 (Dev)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Build and Deploy to S3
+    runs-on: ubuntu-22.04
+
+    env:
+      AWS_REGION: ap-northeast-2
+      S3_BUCKET: modie-fe-prod
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}
+  
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Vite App
+        run: yarn build
+
+      - name: Deploy to S3 (Overwrite)
+        run: aws s3 sync dist/ s3://$S3_BUCKET --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ap-northeast-2
+
+      - name: Invalidate CloudFront Cache
+        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID_PROD --paths "/*"

--- a/.github/workflows/cicd-prod.yml
+++ b/.github/workflows/cicd-prod.yml
@@ -3,7 +3,7 @@ name: Deploy Vite to S3 (Dev)
 on:
   push:
     branches:
-      - main
+      - dev
 
 jobs:
   deploy:
@@ -12,25 +12,36 @@ jobs:
 
     env:
       AWS_REGION: ap-northeast-2
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       S3_BUCKET: modie-fe-prod
       CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }}
-  
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up Node.js and Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22.13.1 
+          cache: 'yarn'
+
+      - name: Install specific Yarn version
+        run: |
+          corepack enable
+          yarn set version 1.22.22  # Yarn 1.22.22 버전 고정
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
       - name: Build Vite App
-        run: yarn build
+        run: |
+          set -e  # 오류 발생 시 즉시 종료
+          yarn build
 
       - name: Deploy to S3 (Overwrite)
-        run: aws s3 sync dist/ s3://$S3_BUCKET --delete
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ap-northeast-2
+        run: aws s3 sync dist/ s3://$S3_BUCKET
 
       - name: Invalidate CloudFront Cache
-        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID_PROD --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,6 +10,13 @@ jobs:
     name: Build and Deploy to S3
     runs-on: ubuntu-22.04
 
+    env:
+      AWS_REGION: ap-northeast-2
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      S3_BUCKET: modie-fe-dev
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -29,14 +36,12 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build Vite App
-        run: yarn build
+        run: |
+          set -e  # 오류 발생 시 즉시 종료
+          yarn build
 
       - name: Deploy to S3 (Overwrite)
-        run: aws s3 sync dist/ s3://$S3_BUCKET --exact-timestamps
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ap-northeast-2
+        run: aws s3 sync dist/ s3://$S3_BUCKET
 
       - name: Invalidate CloudFront Cache
-        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID_DEV --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline for ECR and EC2
+name: Deploy Vite to S3 (Dev)
 
 on:
   push:
@@ -6,104 +6,31 @@ on:
       - dev
 
 jobs:
-  build-and-deploy:
-    name: Build, Push to ECR, Deploy on EC2
+  deploy:
+    name: Build and Deploy to S3
     runs-on: ubuntu-22.04
 
     env:
       AWS_REGION: ap-northeast-2
-      ECR_REGISTRY: 418272768555.dkr.ecr.ap-northeast-2.amazonaws.com
-      ECR_REPOSITORY: modie/modie-fe
+      S3_BUCKET: modie-fe-dev
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          aws-access-key-id: ${{ secrets.ECR_USER_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_USER_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-      - name: Login to Amazon ECR
-        run: |
-          aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin $ECR_REGISTRY
+      - name: Build Vite App
+        run: yarn build
 
-      - name: Build, tag, and push image to Amazon ECR
-        run: |
-          COMMIT_HASH=$(echo $GITHUB_SHA | cut -c1-7)
-          # 최신 이미지 캐시 활용 및 latest 태그 추가
-          docker build --cache-from=type=registry,ref=$ECR_REGISTRY/$ECR_REPOSITORY:latest \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:$COMMIT_HASH \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+      - name: Deploy to S3 (Overwrite)
+        run: aws s3 sync dist/ s3://$S3_BUCKET --delete
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ap-northeast-2
 
-          # 이미지 Push
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$COMMIT_HASH
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-
-      - name: Deploy to EC2
-        uses: appleboy/ssh-action@master
-        with:
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.USER }}
-          script: |
-            COMMIT_HASH=$(echo $GITHUB_SHA | cut -c1-7)
-            if [[ -z "$COMMIT_HASH" ]]; then
-              echo "❌ COMMIT_HASH가 설정되지 않았습니다. 최신 태그를 가져옵니다."
-              
-              # AWS ECR에서 최신 태그 가져오기
-              COMMIT_HASH=$(aws ecr describe-images --repository-name modie/modie-fe \
-                --region ap-northeast-2 --query 'sort_by(imageDetails,& imagePushedAt)[-1].imageTags[0]' --output text)
-      
-              # 값이 없으면 오류 처리
-              if [[ -z "$COMMIT_HASH" || "$COMMIT_HASH" == "None" ]]; then
-                echo "❌ 최신 태그를 가져오지 못했습니다. 배포 중단!"
-                exit 1
-              fi
-            fi
-
-            echo "🚀 사용할 Docker 태그: $COMMIT_HASH"   
-
-            # aws 로그인
-            aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 418272768555.dkr.ecr.ap-northeast-2.amazonaws.com/modie/modie-fe
-            docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$COMMIT_HASH
-
-            # Nginx 설정 파일 경로
-            NGINX_CONFIG=/etc/nginx/sites-enabled/default
-            
-            # 기존 컨테이너 확인 및 포트 설정
-            PORT=4173
-            OTHER_PORT=4174
-            if docker ps | grep -q "0.0.0.0:4173"; then
-              PORT=4174
-              OTHER_PORT=4173
-              BG_MODE=green
-            else
-              PORT=4173
-              OTHER_PORT=4174
-              BG_MODE=blue
-            fi
-            
-            # 새 컨테이너 실행
-            docker run -d -p $PORT:4173 --name modie-fe-$PORT 418272768555.dkr.ecr.ap-northeast-2.amazonaws.com/modie/modie-fe:$COMMIT_HASH
-            
-            # nginx 설정 변경
-            sudo sed -i "s|set \$active_frontend front-.*;|set \$active_frontend front-$BG_MODE;|g" $NGINX_CONFIG
-
-            # 🔥 Nginx 설정 테스트 후 적용 (실패 시 롤백)
-            if sudo nginx -t; then
-              sudo systemctl reload nginx
-              echo "✅ Nginx 설정이 성공적으로 적용되었습니다!"
-            else
-              echo "❌ Nginx 설정 오류 발생! 롤백 수행"
-              docker stop modie-fe-$PORT
-              docker rm modie-fe-$PORT
-              exit 1
-            fi
-          
-            docker stop modie-fe-$OTHER_PORT || true
-            docker rm modie-fe-$OTHER_PORT || true
-            
-            echo "배포완료"
+      - name: Invalidate CloudFront Cache
+        run: aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID_DEV --paths "/*"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,14 +10,20 @@ jobs:
     name: Build and Deploy to S3
     runs-on: ubuntu-22.04
 
-    env:
-      AWS_REGION: ap-northeast-2
-      S3_BUCKET: modie-fe-dev
-      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: Set up Node.js and Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22.13.1 
+          cache: 'yarn'
+
+      - name: Install specific Yarn version
+        run: |
+          corepack enable
+          yarn set version 1.22.22  # Yarn 1.22.22 버전 고정
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -26,7 +32,7 @@ jobs:
         run: yarn build
 
       - name: Deploy to S3 (Overwrite)
-        run: aws s3 sync dist/ s3://$S3_BUCKET --delete
+        run: aws s3 sync dist/ s3://$S3_BUCKET --exact-timestamps
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
### Description

EC2 기반 배포 방식을 제거하고, S3 + CloudFront 기반으로 변경하는 CI/CD 파이프라인을 추가했습니다.

### Changes Made

1. EC2 배포 삭제 및 S3 배포 방식 적용
2. Dev 환경에서는 `modie-fe-dev` S3 버킷으로 배포
3. Prod 환경에서는 `modie-fe-prod` S3 버킷으로 배포
4. CloudFront 캐시 무효화 적용

### Screenshots or Video

변경된 사항이 UI에 영향을 미치지 않습니다.

### Testing
1. GitHub Actions를 실행하여 S3 업로드 및 CloudFront 캐시 무효화 확인
2. 브라우저에서 `dev.modie.site` 및 `modie.site` 정상 동작 확인

### Checklist
- [x] 코드가 정상적으로 실행되는지 확인했습니다.
- [x] GitHub Actions 실행 결과를 검토했습니다.
- [x] CloudFront 캐시 무효화가 정상적으로 동작하는지 테스트했습니다.
- [x] 관련 문서를 업데이트했습니다.

### Additional Notes
추가 개선 사항이 있다면 피드백 부탁드립니다!